### PR TITLE
Bump up ring versioning for Apple M1 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ repository = "https://github.com/ctz/sct.rs"
 categories = ["network-programming", "cryptography"]
 
 [dependencies]
-ring = "0.16.0"
+ring = "0.16.20"
 untrusted = "0.7.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sct"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2018"
 authors = ["Joseph Birr-Pixton <jpixton@gmail.com>"]
 description = "Certificate transparency SCT verification library"


### PR DESCRIPTION
As stated on https://github.com/briansmith/ring/issues/1163#issuecomment-750405885, since it's breaking my software: https://github.com/umccr/htsget-rs/issues/2