### PR TITLE
Prepare for 0.7.1 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sct"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 rust-version = "1.61"
 authors = ["Joseph Birr-Pixton <jpixton@gmail.com>"]


### PR DESCRIPTION
Proposed release notes:

- Update to *ring* 0.17
- MSRV is now 1.61

Diffs: https://github.com/rustls/sct.rs/compare/5b9bbbd310e21c9b4e6be714695b7b4dda2bab19...main